### PR TITLE
Update the name of xicore binary to "xi-core"

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Screenshot:
 * load (`ctrl-o`), save (`ctrl-s`) and save-as (`ctrl-shift-s`) using GTK dialogs,
 * F1 to line-wrap
 
-You must specify a path to the `xicore` executable (build by cargo inside
+You must specify a path to the `xi-core` executable (build by cargo inside
 the `rust` subdirectory of xi-editor). Works with the xi-editor commit ` 7f7b885`,
 but the HEAD is a good bet.
 
 ## Example usage
 
-`xicore=../xi-editor/rust/target/debug/xicore cargo run README.md`
+`xicore=../xi-editor/rust/target/debug/xi-core cargo run README.md`

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ extern crate clipboard;
 
 fn main() {
     let filename = std::env::args().nth(1);
-    let core_path = std::env::var("xicore").unwrap_or("../xi-editor/rust/target/debug/xicore".into());
+    let core_path = std::env::var("xicore").unwrap_or("../xi-editor/rust/target/debug/xi-core".into());
 
     // I read that GTK on Mac needs to be in the main thread. We must let it have it.
     ::std::thread::spawn(move || {


### PR DESCRIPTION
xi-editor changed its binary name to xi-core in google/xi-editor@5cd66fc

This change means that xi_glium is more likely to work with the default paths.
